### PR TITLE
Updated peer dependency; gatsby^3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "^2.1.2"
   },
   "peerDependencies": {
-    "gatsby": "^2.24.91"
+    "gatsby": "^3.0.3"
   },
   "engines": {
     "node": ">=6.0"


### PR DESCRIPTION
appears to work as expected on gatsby 3